### PR TITLE
Avoid needing `replace_na()` entirely

### DIFF
--- a/R/dag_diagrammer.R
+++ b/R/dag_diagrammer.R
@@ -213,8 +213,7 @@ dag_diagrammer = function(graph, wrapWidth = 24, shortLabel = FALSE) {
   ### add egdes if applicable
   if (nrow(edgeDF) > 0) {
     ## use dashed for type = extract
-    edgeDF$style = ifelse(edgeDF$type == "extract","dashed","solid") %>%
-      tidyr::replace_na("solid")
+    edgeDF$style = ifelse(edgeDF$type != "extract" | is.na(edgeDF$type),"solid","dashed")
     edgeDF = DiagrammeR::create_edge_df(from = edgeDF$from,
                                         to = edgeDF$to,
                                         style = edgeDF$style)


### PR DESCRIPTION
We are planning on releasing tidyr 1.2.0 this week. 

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run this example:

``` r
library(causact)

# Create a graph with 2 connected nodes
dag_create() %>%
  dag_node("X") %>%
  dag_node("Y") %>%
  dag_edge(from = "X", to = "Y") %>%
  dag_render(shortLabel = TRUE)
#> Error in `stop_vctrs()` at vctrs/R/conditions.R:72:2:
#> ! Can't convert `replace` <character> to match type of `data` <logical>.
#> Run `rlang::last_error()` to see where the error occurred.
```

The problem comes down to an unfortunate issue where `ifelse(NA, "foo", "bar")` will return a logical `NA` rather than a character `NA_character_` value (this happens in the code I changed below). You then try to pipe this into `replace_na()` and attempt to replace missings in a _logical_ vector with a _character_ value. This is no longer allowed in `replace_na()` for type stability and safety reasons.

This PR attempts to fix this issue by removing the need for `replace_na()` at all. However, I couldn't test your package locally due to some Python issues, so please test this against the dev version of tidyr to see if everything else passes cleanly.

Sorry we didn't detect this earlier, this issue was masked by a DiagrammeR issue that was just fixed.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!